### PR TITLE
REFEACT: auth 관련 API 리팩토링

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -29,17 +29,15 @@ export class AuthController {
   @ApiResponse({
     status: 400,
     description: 'Error',
-    type: String,
   })
   @Post('login')
   async login(
     @Body() body: UserLoginRequestDto,
     @Res({ passthrough: true }) res: Response,
-  ): Promise<string> {
+  ): Promise<number> {
     const sessionId = await this.authService.sessionLogin(body);
 
-    // 이거 스트링인데 인터셉터로 넘버로 가공해서 넘겨주기
-    const userId = await this.authService.setSessionInformationInRedis(
+    const userId = await this.authService.setSessionInformation(
       sessionId,
       body,
     );
@@ -53,15 +51,24 @@ export class AuthController {
     return userId;
   }
 
+  @ApiOperation({ summary: '로그아웃' })
+  @ApiResponse({
+    status: 200,
+    description: '로그아웃 성공',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Error',
+  })
   @Delete('logout')
   async logout(
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ): Promise<number> {
     const sessionId = req.cookies.sessionId;
-    
+
     res.clearCookie('sessionId');
 
-    return await this.authService.deleteSessionInformationInRedis(sessionId);
+    return await this.authService.deleteSessionInformation(sessionId);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -43,10 +43,10 @@ export class AuthService {
     return sessionId;
   }
 
-  async setSessionInformationInRedis(
+  async setSessionInformation(
     sessionId: string,
     body: UserLoginRequestDto,
-  ): Promise<string> {
+  ): Promise<number> {
     const { email } = body;
     const isExistedSessionId = await this.redis.hget(sessionId, 'id');
 
@@ -64,10 +64,12 @@ export class AuthService {
     // 숫자 순서대로 초, 분, 시, 일 (7일간 DB에 보관 이후 자동 삭제)
     await this.redis.expire(sessionId, 60 * 60 * 24 * 7);
 
-    return await this.redis.hget(sessionId, 'id');
+    const userId = await this.redis.hget(sessionId, 'id');
+
+    return parseInt(userId, 10);
   }
 
-  async deleteSessionInformationInRedis(sessionId: string): Promise<number> {
+  async deleteSessionInformation(sessionId: string): Promise<number> {
     return await this.redis.del(sessionId);
   }
 }


### PR DESCRIPTION
- setSessionInformationInRedis, deleteSessionInformationInRedis 메소드명 수정
- 로그아웃 API에 Swagger 데코레이터 추가
- 로그인 API 리턴 타입 number로 수정